### PR TITLE
Feature/7158 format file size

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ Once you have the repo cloned you can run it.
 npm start
 ```
 
+## Debugging the app
+
+The app can be debugged in VS Code if is has been started using the following command:
+
+```bash
+npm start debug
+```
+
+
+## Running the unit tests
+
+The unit tests can be run using the following command:
+
+```bash
+npm test
+```
+
 ## Contributing to this project
 
 If you have an idea you'd like to contribute please log an issue.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-register-of-documents-frontend",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "DEFRA Public Register of Documents frontend",
   "main": "server.js",
   "homepage": "https://github.com/DEFRA/public-register-of-documents-frontend#readme",

--- a/src/modules/view-permit-details.njk
+++ b/src/modules/view-permit-details.njk
@@ -60,7 +60,7 @@
                 <a href="/download?document={{ document.downloadURL }}" target="_blank">{{ document.title }}</a>
               </p>
               <p id="document-detail-{{ loop.index }}" class="govuk-body-s">{{ document.activityGrouping }}</p>
-              <p id="document-detail-size-{{ loop.index }}" class="govuk-body-xs">{{ document.fileSize }} MB - Updated {{ document.uploadedDate }}</p>
+              <p id="document-detail-size-{{ loop.index }}" class="govuk-body-xs">{{ document.fileSizeFormatted }} - Updated {{ document.uploadedDate }}</p>
 
               <hr id="document-list-separator-{{ loop.index }}">
           {% endfor %}

--- a/src/modules/view-permit-details.route.js
+++ b/src/modules/view-permit-details.route.js
@@ -12,6 +12,9 @@ const { Views } = require('../constants')
 // const AppInsightsService = require('../services/app-insights.service')
 // const appInsightsService = new AppInsightsService()
 
+const KB = 'KB'
+const MB = 'MB'
+
 module.exports = {
   method: 'GET',
   handler: async (request, h) => {
@@ -48,6 +51,13 @@ module.exports = {
 
     if (permitData.statusCode === 404) {
       logger.info(`Permit number ${id} not found`)
+    }
+
+    if (permitData && permitData.result && permitData.result.documents) {
+      permitData.result.documents.forEach((document) => {
+        // Document file size is initially in MB so convert to KB if is less than 1 MB
+        document.fileSizeFormatted = document.fileSize < 1 ? `${document.fileSize * 1000} ${KB}` : `${document.fileSize} ${MB}`
+      })
     }
 
     return h.view(Views.VIEW_PERMIT_DETAILS.route, {

--- a/src/modules/view-permit-details.route.js
+++ b/src/modules/view-permit-details.route.js
@@ -4,6 +4,7 @@ const Hoek = require('hoek')
 const { logger } = require('defra-logging-facade')
 const { getQueryData } = require('@envage/hapi-govuk-journey-map')
 
+const { formatFileSize } = require('../utils/general')
 const MiddlewareService = require('../services/middleware.service')
 const { Views } = require('../constants')
 
@@ -11,9 +12,6 @@ const { Views } = require('../constants')
 // Story 7158 (View permit documents, view permit page)
 // const AppInsightsService = require('../services/app-insights.service')
 // const appInsightsService = new AppInsightsService()
-
-const KB = 'KB'
-const MB = 'MB'
 
 module.exports = {
   method: 'GET',
@@ -56,7 +54,7 @@ module.exports = {
     if (permitData && permitData.result && permitData.result.documents) {
       permitData.result.documents.forEach((document) => {
         // Document file size is initially in MB so convert to KB if is less than 1 MB
-        document.fileSizeFormatted = document.fileSize < 1 ? `${document.fileSize * 1000} ${KB}` : `${document.fileSize} ${MB}`
+        document.fileSizeFormatted = formatFileSize(document.fileSize)
       })
     }
 

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const KB = 'KB'
+const MB = 'MB'
+
 const contentTypes = {
   msg: 'application/vnd.ms-outlook',
   pdf: 'application/pdf',
@@ -17,6 +20,11 @@ const getContentType = (fileExtension) => {
   return contentTypes[fileExtension]
 }
 
+const formatFileSize = (sizeInMB) => {
+  return sizeInMB < 1 ? `${sizeInMB * 1000} ${KB}` : `${sizeInMB} ${MB}`
+}
+
 module.exports = {
+  formatFileSize,
   getContentType
 }

--- a/test/data/permit-data.js
+++ b/test/data/permit-data.js
@@ -8,7 +8,7 @@ module.exports = {
     documents: [{
       title: 'Compliance Returns Correspondence Apr to Jun 2016 Rejected',
       fileType: null,
-      fileSize: 10,
+      fileSize: 0.001,
       activityGrouping: 'Waste Returns',
       uploadedDate: '12/10/1985',
       downloadURL: 'PublicRegister-Dummy/00000001.msg'

--- a/test/routes/download.route.test.js
+++ b/test/routes/download.route.test.js
@@ -29,8 +29,6 @@ describe('Download route', () => {
   })
 
   afterAll((done) => {
-    jest.clearAllMocks()
-
     server.events.on('stop', () => {
       done()
     })

--- a/test/routes/enter-permit-number.route.test.js
+++ b/test/routes/enter-permit-number.route.test.js
@@ -30,12 +30,14 @@ describe('Enter Permit Number route', () => {
   })
 
   afterAll((done) => {
-    jest.clearAllMocks()
-
     server.events.on('stop', () => {
       done()
     })
     server.stop()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   describe('GET', () => {

--- a/test/routes/epr-redirect.route.test.js
+++ b/test/routes/epr-redirect.route.test.js
@@ -13,12 +13,14 @@ describe('ePR Redirect route', () => {
   })
 
   afterAll((done) => {
-    jest.clearAllMocks()
-
     server.events.on('stop', () => {
       done()
     })
     server.stop()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   describe('GET:', () => {

--- a/test/routes/home.route.test.js
+++ b/test/routes/home.route.test.js
@@ -39,12 +39,14 @@ describe('Home route', () => {
   })
 
   afterAll((done) => {
-    jest.clearAllMocks()
-
     server.events.on('stop', () => {
       done()
     })
     server.stop()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   describe('GET:', () => {

--- a/test/routes/service-status.route.test.js
+++ b/test/routes/service-status.route.test.js
@@ -27,12 +27,14 @@ describe('Enter Permit Number route', () => {
   })
 
   afterAll((done) => {
-    jest.clearAllMocks()
-
     server.events.on('stop', () => {
       done()
     })
     server.stop()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   describe('GET', () => {

--- a/test/routes/view-permit-details-deep-link.route.test.js
+++ b/test/routes/view-permit-details-deep-link.route.test.js
@@ -45,8 +45,6 @@ describe('View Permit Details Deep Link route', () => {
   })
 
   afterAll((done) => {
-    jest.clearAllMocks()
-
     server.events.on('stop', () => {
       done()
     })
@@ -171,7 +169,7 @@ describe('View Permit Details Deep Link route', () => {
         expect(element).toBeTruthy()
 
         element = document.querySelector(`#${elementIDs.documentsPanel.documentDetailSize}-1`)
-        expect(TestHelper.getTextContent(element)).toEqual('10 MB - Updated 12/10/1985')
+        expect(TestHelper.getTextContent(element)).toEqual('1 KB - Updated 12/10/1985')
         expect(element).toBeTruthy()
       })
 

--- a/test/routes/view-permit-details.route.test.js
+++ b/test/routes/view-permit-details.route.test.js
@@ -181,7 +181,7 @@ describe('View Permit Details route', () => {
         expect(element).toBeTruthy()
 
         element = document.querySelector(`#${elementIDs.documentsPanel.documentDetailSize}-1`)
-        expect(TestHelper.getTextContent(element)).toEqual('10 MB - Updated 12/10/1985')
+        expect(TestHelper.getTextContent(element)).toEqual('1 KB - Updated 12/10/1985')
         expect(element).toBeTruthy()
       })
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -27,12 +27,14 @@ describe('Server', () => {
   })
 
   afterAll((done) => {
-    jest.clearAllMocks()
-
     server.events.on('stop', () => {
       done()
     })
     server.stop()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   it('should successfully connect to the server', async () => {

--- a/test/services/middleware.service.test.js
+++ b/test/services/middleware.service.test.js
@@ -55,7 +55,7 @@ describe('Middleware service', () => {
 
       expect(permitData.result.documents[0].title).toEqual('Compliance Returns Correspondence Apr to Jun 2016 Rejected')
       expect(permitData.result.documents[0].fileType).toBeNull()
-      expect(permitData.result.documents[0].fileSize).toEqual(10)
+      expect(permitData.result.documents[0].fileSize).toEqual(0.001)
       expect(permitData.result.documents[0].activityGrouping).toEqual('Waste Returns')
       expect(permitData.result.documents[0].uploadedDate).toEqual('12/10/1985')
       expect(permitData.result.documents[0].downloadURL).toEqual('PublicRegister-Dummy/00000001.msg')

--- a/test/utilities/general.test.js
+++ b/test/utilities/general.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const { formatFileSize, getContentType } = require('../../src/utils/general')
+
+describe('Utils / General', () => {
+  describe('formatFileSize method', () => {
+    it('should format the file size correctly when the file size is less than 1MB', async () => {
+      expect(formatFileSize('0')).toEqual('0 KB')
+      expect(formatFileSize('0.5')).toEqual('500 KB')
+      expect(formatFileSize('0.999')).toEqual('999 KB')
+    })
+
+    it('should format the file size correctly when the file size is 1MB or higher', async () => {
+      expect(formatFileSize('1')).toEqual('1 MB')
+      expect(formatFileSize('1.001')).toEqual('1.001 MB')
+      expect(formatFileSize('1.01')).toEqual('1.01 MB')
+      expect(formatFileSize('1.1')).toEqual('1.1 MB')
+      expect(formatFileSize('1.5')).toEqual('1.5 MB')
+    })
+  })
+
+  describe('getContentType method', () => {
+    it('should get the correct content type', async () => {
+      expect(getContentType('pdf')).toEqual('application/pdf')
+    })
+  })
+})

--- a/test/utilities/test-helper.js
+++ b/test/utilities/test-helper.js
@@ -35,10 +35,6 @@ module.exports = class TestHelper {
     }
     const response = await server.inject(options)
 
-    if (response.statusCode !== expectedResponseCode) {
-      console.log(response)
-    }
-
     expect(response.statusCode).toBe(expectedResponseCode)
     return TestHelper.getDocument(response)
   }


### PR DESCRIPTION
Story 7158 - View Permit Documents

This additional change amends the display of file sizes of documents listed in the View Permit Details screen so that if the file size is 1MB or above then it is displayed in MB, otherwise it is displayed in KB.