### PR TITLE
Fixed build - Added gulpfile to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN npm install -g gulp
 RUN npm link gulp
 
 # Install app dependencies
+COPY --chown=node:node gulpfile.js ./gulpfile.js
 COPY --chown=node:node package*.json ./
 COPY --chown=node:node application.scss ./
 RUN npm install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-register-of-documents-frontend",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "DEFRA Public Register of Documents frontend",
   "main": "server.js",
   "homepage": "https://github.com/DEFRA/public-register-of-documents-frontend#readme",


### PR DESCRIPTION
Version 0.9.0 added the use of Gulp to compile the SCSS files. This change failed because gulpfile.js was not included in the Dockerfile. This change fixes that problem.