### PR TITLE
Permit number querystring parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-register-of-documents-frontend",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "DEFRA Public Register of Documents frontend",
   "main": "server.js",
   "homepage": "https://github.com/DEFRA/public-register-of-documents-frontend#readme",

--- a/src/modules/enter-permit-number.route.js
+++ b/src/modules/enter-permit-number.route.js
@@ -53,7 +53,9 @@ module.exports = [
       }
 
       if (permitExists) {
-        return h.redirect(`/${Views.VIEW_PERMIT_DETAILS.route}/${santisedPermitNumber}?register=${context.register}`)
+        return h.redirect(
+          `/${Views.VIEW_PERMIT_DETAILS.route}?permitNumber=${santisedPermitNumber}&register=${context.register}`
+        )
       } else {
         return raiseCustomValidationError(
           h,

--- a/src/modules/map.yml
+++ b/src/modules/map.yml
@@ -38,7 +38,7 @@ contact-complete:
     - hide-back-link
 
 permit-not-found:
-  path: /permit-not-found/{id}
+  path: /permit-not-found
   route: permit-not-found.route
   tags:
     - hide-back-link
@@ -54,5 +54,5 @@ something-went-wrong:
   route: something-went-wrong.route
 
 view-permit-documents:
-  path: /view-permit-documents/{id}
+  path: /view-permit-documents
   route: view-permit-documents.route

--- a/src/modules/permit-not-found.route.js
+++ b/src/modules/permit-not-found.route.js
@@ -6,11 +6,11 @@ module.exports = {
   method: 'GET',
   handler: async (request, h) => {
     let permitNumber
-    const register =
-      request.query && request.query.register ? decodeURIComponent(request.query.register) : 'Not specified'
+    let register
 
-    if (request.params) {
-      permitNumber = decodeURIComponent(request.params.id)
+    if (request.query) {
+      permitNumber = decodeURIComponent(request.query.permitNumber)
+      register = request.query.register ? decodeURIComponent(request.query.register) : 'Not specified'
     }
 
     return h.view(Views.PERMIT_NOT_FOUND.route, {

--- a/src/modules/view-permit-documents.route.js
+++ b/src/modules/view-permit-documents.route.js
@@ -48,9 +48,9 @@ module.exports = [
         }
 
         return h.redirect(
-          `/${Views.PERMIT_NOT_FOUND.route}/${encodeURIComponent(params.permitNumber)}?register=${encodeURIComponent(
-            params.register
-          )}`
+          `/${Views.PERMIT_NOT_FOUND.route}?permitNumber=${encodeURIComponent(
+            params.permitNumber
+          )}&register=${encodeURIComponent(params.register)}`
         )
       }
 
@@ -97,12 +97,9 @@ const _getParams = request => {
   const UPLOADED_AFTER_ID = 'uploaded-after'
   const UPLOADED_BEFORE_ID = 'uploaded-before'
 
-  if (request.params) {
-    params.permitNumber = request.params.id
-  }
-
   if (request.method.toLowerCase() === 'get') {
     // GET
+    params.permitNumber = request.query.permitNumber
     params.referer = request.query.Referer
     params.register = request.query.register
     params.licenceNumber = request.query.licenceNumber

--- a/test/routes/enter-permit-number.route.test.js
+++ b/test/routes/enter-permit-number.route.test.js
@@ -129,7 +129,9 @@ describe('Enter Permit Number route', () => {
 
         response = await TestHelper.submitPostRequest(server, postOptions)
 
-        expect(response.headers.location).toEqual(`${nextUrlKnownPermitNumber}/${permitNumber}?register=${register}`)
+        expect(response.headers.location).toEqual(
+          `${nextUrlKnownPermitNumber}?permitNumber=${permitNumber}&register=${register}`
+        )
       })
 
       it('should redirect to ePR when the user has said that they do not know then permit number', async () => {

--- a/test/routes/permit-not-found.route.test.js
+++ b/test/routes/permit-not-found.route.test.js
@@ -4,9 +4,9 @@ const server = require('../../src/server')
 const TestHelper = require('../utilities/test-helper')
 
 describe('Permit not found route', () => {
-  const unknownPermitNumber = 'ABC123'
+  const permitNumber = 'ABC123'
   const register = 'Radioactive Substances'
-  const url = `/permit-not-found/${unknownPermitNumber}?register=${register}`
+  const url = `/permit-not-found?permitNumber=${permitNumber}&register=${register}`
 
   const elementIDs = {
     pageHeading: 'page-heading',
@@ -61,7 +61,7 @@ describe('Permit not found route', () => {
     it('should show the permit number', async () => {
       const element = document.querySelector(`#${elementIDs.permitNumber}`)
       expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual(unknownPermitNumber)
+      expect(TestHelper.getTextContent(element)).toEqual(permitNumber)
     })
 
     it('should show the register', async () => {
@@ -73,7 +73,7 @@ describe('Permit not found route', () => {
     it('should have the "Permit not found" message', async () => {
       const element = document.querySelector(`#${elementIDs.permitNotFoundMessage}`)
       expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual(`Permit number ${unknownPermitNumber} could not be found.`)
+      expect(TestHelper.getTextContent(element)).toEqual(`Permit number ${permitNumber} could not be found.`)
     })
   })
 })

--- a/test/routes/view-permit-documents.route.test.js
+++ b/test/routes/view-permit-documents.route.test.js
@@ -15,8 +15,8 @@ const JourneyMap = require('@envage/hapi-govuk-journey-map')
 describe('View Permit Details route', () => {
   const permitNumber = 'EAWML65519'
   const register = 'Installations'
-  const url = `/view-permit-documents/${permitNumber}`
-  const nextUrlUnknownPermitNumber = `/permit-not-found/${permitNumber}?register=${register}`
+  const url = `/view-permit-documents?permitNumber=${permitNumber}`
+  const nextUrlUnknownPermitNumber = `/permit-not-found?permitNumber=${permitNumber}&register=${register}`
 
   const elementIDs = {
     permitInformation: {
@@ -274,7 +274,7 @@ describe('View Permit Details route', () => {
   describe('GET: Unknown permit number', () => {
     const getOptions = {
       method: 'GET',
-      url: `${url}?register=${register}`
+      url: `${url}&register=${register}`
     }
 
     beforeEach(async () => {
@@ -436,7 +436,7 @@ describe('View Permit Details route', () => {
           search: jest.fn().mockReturnValue(mockData)
         }
       })
-      getOptions.url = `${url}?Referer=EPR&register=${register}`
+      getOptions.url = `${url}&Referer=EPR&register=${register}`
 
       expect(AppInsightsService.prototype.trackEvent).toBeCalledTimes(0)
 
@@ -466,7 +466,7 @@ describe('View Permit Details route', () => {
           })
         }
       })
-      getOptions.url = `${url}xxx?Referer=EPR&register=${register}`
+      getOptions.url = `${url}xxx&Referer=EPR&register=${register}`
 
       expect(AppInsightsService.prototype.trackEvent).toBeCalledTimes(0)
 


### PR DESCRIPTION
Changed permitNumber so that it is passed around as a querystring parameter rather than being part of the URL. This is because it is possible for permit numbers to contain forward slashes.