### PR TITLE
Permit number reformatting for exact match search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-register-of-documents-frontend",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "DEFRA Public Register of Documents frontend",
   "main": "server.js",
   "homepage": "https://github.com/DEFRA/public-register-of-documents-frontend#readme",

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,15 @@ Constants.DATE_FORMAT_DMY = 'DD/MM/YYYY'
 Constants.DATE_FORMAT_DMY_WITH_HMS = 'DD/MM/YYYY HH:mm:ss'
 Constants.DATE_FORMAT_FULL = 'Do MMMM YYYY'
 
+Constants.Registers = {
+  WASTE_OPERATIONS: 'Waste Operations',
+  END_OF_LIFE_VEHICLES: 'End of Life Vehicles (ATF Register)',
+  INSTALLATIONS: 'Installations',
+  RADIOACTIVE_SUBSTANCES: 'Radioactive Substances',
+  DISCHARGES_TO_WATER_AND_GROUNDWATER: 'Water Quality Discharge Consents',
+  DISCHARGES_TO_WATER_AND_GROUNDWATER_DISPLAY_VALUE: 'Discharges to water and groundwater'
+}
+
 Constants.Views = {
   CONTACT: {
     route: 'contact',
@@ -41,7 +50,7 @@ Constants.Views = {
     route: 'something-went-wrong',
     pageHeading: 'Oops, something went wrong'
   },
-  VIEW_PERMIT_DETAILS: {
+  VIEW_PERMIT_DOCUMENTS: {
     route: 'view-permit-documents',
     pageHeading: 'Permit details'
   }

--- a/src/modules/enter-permit-number.route.js
+++ b/src/modules/enter-permit-number.route.js
@@ -35,7 +35,7 @@ module.exports = [
         return h.continue
       }
 
-      const santisedPermitNumber = sanitisePermitNumber(context.permitNumber)
+      const santisedPermitNumber = sanitisePermitNumber(context.register, context.permitNumber)
 
       const middlewareService = new MiddlewareService()
       const permitExists = await middlewareService.checkPermitExists(santisedPermitNumber, context.register)
@@ -47,6 +47,7 @@ module.exports = [
           name: 'KPI 3 - User-entered permit number has failed to match a permit',
           properties: {
             permitNumber: context.permitNumber,
+            sanitisedPermitNumber: santisedPermitNumber,
             register: context.register
           }
         })
@@ -54,7 +55,7 @@ module.exports = [
 
       if (permitExists) {
         return h.redirect(
-          `/${Views.VIEW_PERMIT_DETAILS.route}?permitNumber=${santisedPermitNumber}&register=${context.register}`
+          `/${Views.VIEW_PERMIT_DOCUMENTS.route}?permitNumber=${santisedPermitNumber}&register=${context.register}`
         )
       } else {
         return raiseCustomValidationError(

--- a/src/modules/select-register.njk
+++ b/src/modules/select-register.njk
@@ -15,29 +15,7 @@
       }
     },
     errorMessage: fieldErrors['register'],
-    items: [
-      {
-        value: "Waste Operations",
-        text: "Waste Operations",
-        checked: true
-      },
-      {          
-        value: "End of Life Vehicles (ATF Register)",
-        text: "End of Life Vehicles (ATF Register)"
-      },
-      {
-        value: "Installations",
-        text: "Installations"
-      },
-      {
-        value: "Radioactive Substances",
-        text: "Radioactive Substances"
-      },
-      {
-        value: "Discharges to water and groundwater",
-        text: "Discharges to water and groundwater"
-      }
-    ]
+    items: registerItems
   }) }}
 
   {{ govukButton({

--- a/src/modules/select-register.njk
+++ b/src/modules/select-register.njk
@@ -15,7 +15,7 @@
       }
     },
     errorMessage: fieldErrors['register'],
-    items: registerItems
+    items: registers
   }) }}
 
   {{ govukButton({

--- a/src/modules/select-register.route.js
+++ b/src/modules/select-register.route.js
@@ -2,7 +2,7 @@
 
 const { Registers, Views } = require('../constants')
 
-const registerItems = [
+const registers = [
   {
     value: Registers.WASTE_OPERATIONS,
     text: Registers.WASTE_OPERATIONS,
@@ -48,6 +48,6 @@ const _getContext = request => {
   return {
     pageHeading: Views.SELECT_REGISTER.pageHeading,
     register: request.payload ? request.payload.register : null,
-    registerItems
+    registers
   }
 }

--- a/src/modules/select-register.route.js
+++ b/src/modules/select-register.route.js
@@ -1,6 +1,30 @@
 'use strict'
 
-const { Views } = require('../constants')
+const { Registers, Views } = require('../constants')
+
+const registerItems = [
+  {
+    value: Registers.WASTE_OPERATIONS,
+    text: Registers.WASTE_OPERATIONS,
+    checked: true
+  },
+  {
+    value: Registers.WASTE_OPERATIONS,
+    text: Registers.END_OF_LIFE_VEHICLES
+  },
+  {
+    value: Registers.INSTALLATIONS,
+    text: Registers.INSTALLATIONS
+  },
+  {
+    value: Registers.RADIOACTIVE_SUBSTANCES,
+    text: Registers.RADIOACTIVE_SUBSTANCES
+  },
+  {
+    value: Registers.DISCHARGES_TO_WATER_AND_GROUNDWATER,
+    text: Registers.DISCHARGES_TO_WATER_AND_GROUNDWATER_DISPLAY_VALUE
+  }
+]
 
 module.exports = [
   {
@@ -23,6 +47,7 @@ module.exports = [
 const _getContext = request => {
   return {
     pageHeading: Views.SELECT_REGISTER.pageHeading,
-    register: request.payload ? request.payload.register : null
+    register: request.payload ? request.payload.register : null,
+    registerItems
   }
 }

--- a/src/modules/view-permit-documents.route.js
+++ b/src/modules/view-permit-documents.route.js
@@ -74,7 +74,7 @@ module.exports = [
         })
       }
 
-      return h.view(Views.VIEW_PERMIT_DETAILS.route, context)
+      return h.view(Views.VIEW_PERMIT_DOCUMENTS.route, context)
     }
   },
   {
@@ -85,7 +85,7 @@ module.exports = [
       const context = _getContext(request, permitData, params)
       _setTags(context, params)
 
-      return h.view(Views.VIEW_PERMIT_DETAILS.route, context)
+      return h.view(Views.VIEW_PERMIT_DOCUMENTS.route, context)
     }
   }
 ]
@@ -117,6 +117,9 @@ const _getParams = request => {
     }
   } else {
     // POST
+    params.permitNumber = request.payload.permitNumber
+    params.referer = request.payload.Referer
+    params.register = request.payload.register
     params.page = parseInt(request.payload.page) || 1
     params.sort = request.payload.sort || 'newest'
     params.uploadedAfter = request.payload[UPLOADED_AFTER_ID]
@@ -151,6 +154,7 @@ const _getPermitData = async params => {
 
   let permitData = await middlewareService.search(
     params.permitNumber,
+    params.register,
     params.page,
     config.pageSize,
     params.sort,
@@ -164,6 +168,7 @@ const _getPermitData = async params => {
 
     permitData = await middlewareService.search(
       params.permitNumber,
+      params.register,
       params.page,
       config.pageSize,
       params.sort,
@@ -176,6 +181,7 @@ const _getPermitData = async params => {
   if (permitData.statusCode !== 404) {
     const permitDataAllDocumentTypes = await middlewareService.search(
       params.permitNumber,
+      params.register,
       params.page,
       config.pageSize,
       params.sort,
@@ -224,7 +230,7 @@ const _getContext = (request, permitData, params) => {
   const viewData = _buildViewData(permitData, params, permitDetails)
 
   Object.assign(viewData, {
-    pageHeading: Views.VIEW_PERMIT_DETAILS.pageHeading,
+    pageHeading: Views.VIEW_PERMIT_DOCUMENTS.pageHeading,
     id: params.permitNumber,
     permitData
   })
@@ -267,7 +273,7 @@ const _buildViewData = (permitData, params, permitDetails) => {
     viewData.pageCount = lastPage
     viewData.paginationRequired = viewData.pageCount > 1
     viewData.showPaginationSeparator = viewData.previousPage && viewData.nextPage
-    viewData.url = `/${Views.VIEW_PERMIT_DETAILS.route}/${permitData.result.items[0].permitDetails.permitNumber}`
+    viewData.url = `/${Views.VIEW_PERMIT_DOCUMENTS.route}/${permitData.result.items[0].permitDetails.permitNumber}`
   }
 
   viewData.sort = params.sort

--- a/src/services/middleware.service.js
+++ b/src/services/middleware.service.js
@@ -35,13 +35,19 @@ class MiddlewareService {
     return response.body
   }
 
-  async checkPermitExists (permitNumber) {
+  async checkPermitExists (permitNumber, register) {
     const correlationId = uuidv4()
     const options = {
       method: 'HEAD',
       headers: Object.assign(headers, { [CORRELATION_ID_KEY]: correlationId })
     }
-    const url = `${SEARCH_URL}?query=${permitNumber}&filter=PermitNumber eq '${permitNumber}'`
+
+    // TODO: Remove this - temporary workaround
+    if (register === 'Radioactive Substances') {
+      register = 'Radioactive substances'
+    }
+
+    const url = `${SEARCH_URL}?query=${permitNumber}&filter=RegulatedActivityClass eq '${register}' and PermitNumber eq '${permitNumber}'`
 
     logger.info(`Checking permit exists - fetching URL: [${url}] Correlation ID: [${correlationId}]`)
 
@@ -50,11 +56,16 @@ class MiddlewareService {
     return response.status === 200
   }
 
-  async search (permitNumber, page, pageSize, sort, uploadedAfter, uploadedBefore, activityGroupings = []) {
+  async search (permitNumber, register, page, pageSize, sort, uploadedAfter, uploadedBefore, activityGroupings = []) {
     const correlationId = uuidv4()
     const options = {
       method: 'GET',
       headers: Object.assign(headers, { [CORRELATION_ID_KEY]: correlationId })
+    }
+
+    // TODO: Remove this - temporary workaround
+    if (register === 'Radioactive Substances') {
+      register = 'Radioactive substances'
     }
 
     const orderBy = `UploadDate ${sort === 'newest' ? 'desc' : 'asc'}`
@@ -78,7 +89,7 @@ class MiddlewareService {
       activityGroupingFilter = activityGroupingFilter.replace(/ or $/, ')')
     }
 
-    const url = `${SEARCH_URL}?query=${permitNumber}&filter=PermitNumber eq '${permitNumber}'${uploadDateFilters}${activityGroupingFilter}&pageNumber=${page}&pageSize=${pageSize}&orderby=${orderBy}`
+    const url = `${SEARCH_URL}?query=${permitNumber}&filter=RegulatedActivityClass eq '${register}' and PermitNumber eq '${permitNumber}'${uploadDateFilters}${activityGroupingFilter}&pageNumber=${page}&pageSize=${pageSize}&orderby=${orderBy}`
 
     logger.info(`Searching for permit - fetching URL: [${url}] Correlation ID: [${correlationId}]`)
 

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -2,10 +2,14 @@
 
 const moment = require('moment')
 moment.locale('en-GB')
-const { DATE_FORMAT_DMY, DATE_FORMAT_FULL } = require('../constants')
+
+const { Registers, DATE_FORMAT_DMY, DATE_FORMAT_FULL } = require('../constants')
 
 const KB = 'KB'
 const MB = 'MB'
+
+const eawmlPrefix = 'EAWML '
+const eprPrefix = 'EPR-'
 
 const contentTypes = {
   msg: 'application/vnd.ms-outlook',
@@ -46,15 +50,34 @@ const formatExtension = extension => {
   return extension
 }
 
-const sanitisePermitNumber = permitNumber => {
-  if (permitNumber) {
+const sanitisePermitNumber = (register, permitNumber) => {
+  if (register === Registers.WASTE_OPERATIONS) {
     permitNumber = permitNumber
-      .replace(/\s/g, '')
-      .replace(/\//g, '')
-      .replace(/\\/g, '')
-      .replace(/-/g, '')
-      .replace(/\./g, '')
+      .replace(/\/.*$/g, '')
+      .toUpperCase()
+      .replace(/[^A-Z0-9/]/g, '')
+
+    if (permitNumber.match(/^EAWML/g)) {
+      permitNumber = permitNumber.replace(/^EAWML/g, eawmlPrefix)
+    } else if (permitNumber.match(/^EPR/g)) {
+      permitNumber = permitNumber.replace(/^EPR/g, eprPrefix)
+    } else if (permitNumber.match(/^[0-9]*$/g)) {
+      permitNumber = `${eawmlPrefix}${permitNumber}`
+    } else if (permitNumber.match(/^[A-Z0-9]*$/g)) {
+      permitNumber = `${eprPrefix}${permitNumber}`
+    }
+  } else if (register === Registers.INSTALLATIONS || register === Registers.RADIOACTIVE_SUBSTANCES) {
+    permitNumber = permitNumber.toUpperCase().replace(/[^A-Z0-9]/g, '')
+    if (permitNumber.match(/^EPR/g)) {
+      permitNumber = permitNumber.replace(/^EPR/g, eprPrefix)
+    } else if (permitNumber.match(/^[A-Z0-9]*$/g)) {
+      permitNumber = `${eprPrefix}${permitNumber}`
+    }
+  } else if (register === Registers.DISCHARGES_TO_WATER_AND_GROUNDWATER) {
+    permitNumber = permitNumber.toUpperCase().replace(/[^A-Z0-9]/g, '')
+    // TODO other permit number transformations, yet to be defined
   }
+
   return permitNumber
 }
 

--- a/test/routes/enter-permit-number.route.test.js
+++ b/test/routes/enter-permit-number.route.test.js
@@ -123,7 +123,7 @@ describe('Enter Permit Number route', () => {
       })
 
       it('should progress to the next route when the permit number is known', async () => {
-        const permitNumber = 'ABC123'
+        const permitNumber = 'EPR-ABC123CD'
         postOptions.payload.knowPermitNumber = 'yes'
         postOptions.payload.permitNumber = permitNumber
 
@@ -213,7 +213,7 @@ describe('Enter Permit Number route', () => {
         })
 
         postOptions.payload.knowPermitNumber = 'yes'
-        postOptions.payload.permitNumber = 'ABC123'
+        postOptions.payload.permitNumber = 'EPR-ABC123CD'
 
         response = await TestHelper.submitPostRequest(server, postOptions, 400)
 
@@ -243,7 +243,7 @@ describe('Enter Permit Number route', () => {
 
       it('should record the KPI event in AppInsights when a user-entered permit number has failed to match a permit (KPI 3)', async () => {
         postOptions.payload.knowPermitNumber = 'yes'
-        postOptions.payload.permitNumber = 'ABC123'
+        postOptions.payload.permitNumber = 'ABC123CD'
 
         expect(AppInsightsService.prototype.trackEvent).toBeCalledTimes(0)
 
@@ -254,7 +254,11 @@ describe('Enter Permit Number route', () => {
         expect(AppInsightsService.prototype.trackEvent).toBeCalledWith(
           expect.objectContaining({
             name: 'KPI 3 - User-entered permit number has failed to match a permit',
-            properties: { permitNumber: 'ABC123', register: 'Installations' }
+            properties: {
+              permitNumber: 'ABC123CD',
+              sanitisedPermitNumber: 'EPR-ABC123CD',
+              register: 'Installations'
+            }
           })
         )
       })

--- a/test/routes/home.route.test.js
+++ b/test/routes/home.route.test.js
@@ -83,15 +83,4 @@ describe('Home route', () => {
       })
     })
   })
-
-  // This test will be needed when developing Feature 12215 (Monitor performance of service)
-  // it('should create server connection', async () => {
-  //   const options = {
-  //     method: 'GET',
-  //     url: '/'
-  //   }
-  //   const data = await server.inject(options)
-  //   expect(data.statusCode).toBe(200)
-  //   // expect(mockAppInsightsService.trackEvent).toHaveBeenCalledTimes(2)
-  // })
 })

--- a/test/routes/select-register.route.test.js
+++ b/test/routes/select-register.route.test.js
@@ -65,7 +65,7 @@ describe('Select Register route', () => {
       TestHelper.checkRadioOption(
         document,
         elementIDs.registerOption2,
-        'End of Life Vehicles (ATF Register)',
+        'Waste Operations',
         'End of Life Vehicles (ATF Register)',
         false
       )
@@ -80,7 +80,7 @@ describe('Select Register route', () => {
       TestHelper.checkRadioOption(
         document,
         elementIDs.registerOption5,
-        'Discharges to water and groundwater',
+        'Water Quality Discharge Consents',
         'Discharges to water and groundwater',
         false
       )

--- a/test/services/middleware.service.test.js
+++ b/test/services/middleware.service.test.js
@@ -8,7 +8,8 @@ const mockData = require('../data/permit-data')
 
 describe('Middleware service', () => {
   let middlewareService
-  const permitNumber = 'EAWML65519'
+  const permitNumber = 'EAWML 65519'
+  const register = 'Installations'
   const pageNumber = 1
   const pageSize = 20
   const orderBy = 'UploadDate desc'
@@ -29,16 +30,20 @@ describe('Middleware service', () => {
 
     nock(`https://${config.middlewareEndpoint}`)
       .get(
-        `/v1/search?query=${permitNumber}&filter=PermitNumber eq '${permitNumber}' and UploadDate ge 1950-02-01T00:00:00Z and UploadDate le 2021-12-31T00:00:00Z&pageNumber=${pageNumber}&pageSize=${pageSize}&orderby=${orderBy}`
+        `/v1/search?query=${permitNumber}&filter=RegulatedActivityClass eq 'Installations' and PermitNumber eq '${permitNumber}' and UploadDate ge 1950-02-01T00:00:00Z and UploadDate le 2021-12-31T00:00:00Z&pageNumber=${pageNumber}&pageSize=${pageSize}&orderby=${orderBy}`
       )
       .reply(200, mockData)
 
     nock(`https://${config.middlewareEndpoint}`)
-      .head(`/v1/search?query=${permitNumber}&filter=PermitNumber eq '${permitNumber}'`)
+      .head(
+        `/v1/search?query=${permitNumber}&filter=RegulatedActivityClass eq 'Installations' and PermitNumber eq '${permitNumber}'`
+      )
       .reply(200)
 
     nock(`https://${config.middlewareEndpoint}`)
-      .head("/v1/search?query=UNKNOWN_PERMIT_NUMBER&filter=PermitNumber eq 'UNKNOWN_PERMIT_NUMBER'")
+      .head(
+        "/v1/search?query=UNKNOWN_PERMIT_NUMBER&filter=RegulatedActivityClass eq 'Installations' and PermitNumber eq 'UNKNOWN_PERMIT_NUMBER'"
+      )
       .reply(404)
   })
 
@@ -65,13 +70,13 @@ describe('Middleware service', () => {
   describe('checkPermitExists method', () => {
     it('should return true if the permit exists', async () => {
       expect(middlewareService).toBeTruthy()
-      const results = await middlewareService.checkPermitExists(permitNumber)
+      const results = await middlewareService.checkPermitExists(permitNumber, register)
       expect(results).toBeTruthy()
     })
 
     it('should return false if the permit does not exist', async () => {
       expect(middlewareService).toBeTruthy()
-      const results = await middlewareService.checkPermitExists('UNKNOWN_PERMIT_NUMBER')
+      const results = await middlewareService.checkPermitExists('UNKNOWN_PERMIT_NUMBER', register)
       expect(results).toBeFalsy()
     })
   })
@@ -82,6 +87,7 @@ describe('Middleware service', () => {
 
       const permitData = await middlewareService.search(
         permitNumber,
+        register,
         1,
         20,
         'newest',

--- a/test/services/notify-rate-limit.service.test.js
+++ b/test/services/notify-rate-limit.service.test.js
@@ -29,7 +29,7 @@ describe('Notify rate limit service', () => {
       expect(notifyRateLimitService.registerNotifyMessages(DEFAULT_NOTIFY_RATE_RATE_LIMIT + 1)).toBeFalsy()
     })
 
-    it('the rate limit should reset after an hour', () => {
+    it('should reset the rate limit after an hour or more has elapsed', () => {
       expect(notifyRateLimitService.registerNotifyMessages(DEFAULT_NOTIFY_RATE_RATE_LIMIT)).toBeTruthy()
       expect(notifyRateLimitService.registerNotifyMessages(1)).toBeFalsy()
 

--- a/test/utilities/general.test.js
+++ b/test/utilities/general.test.js
@@ -11,25 +11,25 @@ const {
 
 describe('Utils / General', () => {
   describe('formatDate method', () => {
-    it('should format dates correctly', async () => {
+    it('should format dates correctly', () => {
       expect(formatDate('1985-10-29T00:00:00Z')).toEqual('29th October 1985')
     })
   })
 
   describe('formatExtension method', () => {
-    it('should format file extensions correctly', async () => {
+    it('should format file extensions correctly', () => {
       expect(formatExtension('   .pdf   ')).toEqual('PDF')
     })
   })
 
   describe('formatFileSize method', () => {
-    it('should format the file size correctly in KB when the file size is less than 1MB', async () => {
+    it('should format the file size correctly in KB when the file size is less than 1MB', () => {
       expect(formatFileSize('0')).toEqual('0 KB')
       expect(formatFileSize('500000')).toEqual('500 KB')
       expect(formatFileSize('999000')).toEqual('999 KB')
     })
 
-    it('should format the file size correctly in MB when the file size is 1MB or higher', async () => {
+    it('should format the file size correctly in MB when the file size is 1MB or higher', () => {
       expect(formatFileSize('1000000')).toEqual('1 MB')
       expect(formatFileSize('1010000')).toEqual('1.01 MB')
       expect(formatFileSize('1100000')).toEqual('1.1 MB')
@@ -39,35 +39,84 @@ describe('Utils / General', () => {
   })
 
   describe('getContentType method', () => {
-    it('should get the correct content type', async () => {
+    it('should get the correct content type', () => {
       expect(getContentType('pdf')).toEqual('application/pdf')
     })
   })
 
   describe('sanitisePermitNumber method', () => {
-    it('should remove all whitespace characters', async () => {
-      expect(sanitisePermitNumber('  ABC\n123\t456  ')).toEqual('ABC123456')
+    describe('Waste Operations (including End of Life Vehicles) registers', () => {
+      const expectedPermitNumer = 'EAWML 123456'
+      const expectedEprPermitNumer = 'EPR-AB12CD'
+      const registers = ['Waste Operations']
+
+      it('should strip a suffix', () => {
+        registers.forEach(register =>
+          expect(sanitisePermitNumber(register, 'EAWML 123456/A001')).toEqual(expectedPermitNumer)
+        )
+      })
+
+      it('should convert to upper case', () => {
+        registers.forEach(register =>
+          expect(sanitisePermitNumber(register, 'eawml 123456')).toEqual(expectedPermitNumer)
+        )
+      })
+
+      it('should strip all non-alphanumeric characters', () => {
+        registers.forEach(register =>
+          expect(sanitisePermitNumber(register, ' EAWML\n123\t456  !@£$%^&*(/:"<>?')).toEqual('EAWML 123456')
+        )
+      })
+
+      it('should add a space for EAWML permit numbers', () => {
+        registers.forEach(register => expect(sanitisePermitNumber(register, 'EAWML123456')).toEqual('EAWML 123456'))
+      })
+
+      it('should add a hyphen for EPR permit numbers', () => {
+        registers.forEach(register =>
+          expect(sanitisePermitNumber(register, 'EPRAB12CD')).toEqual(expectedEprPermitNumer)
+        )
+      })
+
+      it('should add "EAWML " prefix to the permit number if the permit number only contains numeric characters', () => {
+        registers.forEach(register => expect(sanitisePermitNumber(register, '123456')).toEqual(expectedPermitNumer))
+      })
+
+      it('should add "EPR-" prefix to the permit number if the permit number only contains alphanumeric characters', () => {
+        registers.forEach(register => expect(sanitisePermitNumber(register, 'AB12CD')).toEqual(expectedEprPermitNumer))
+      })
     })
 
-    it('should remove all forward slashes characters', async () => {
-      expect(sanitisePermitNumber('ABC/123/456')).toEqual('ABC123456')
+    describe('Installations and Radioactive Substances registers', () => {
+      const expectedEprPermitNumer = 'EPR-AB12CD'
+      const registers = ['Installations', 'Radioactive Substances']
+
+      it('should strip all non-alphanumeric characters', () => {
+        registers.forEach(register =>
+          expect(sanitisePermitNumber(register, ' EPR-AB\n12\t.CD  !@£$%^&*(/:"<>?')).toEqual(expectedEprPermitNumer)
+        )
+      })
+
+      it('should add a hyphen for EPR permit numbers', () => {
+        registers.forEach(register =>
+          expect(sanitisePermitNumber(register, 'EPRAB12CD')).toEqual(expectedEprPermitNumer)
+        )
+      })
+
+      it('should add "EPR-" prefix to the permit number if the permit number only contains alphanumeric characters', () => {
+        registers.forEach(register => expect(sanitisePermitNumber(register, 'AB12CD')).toEqual(expectedEprPermitNumer))
+      })
     })
 
-    it('should remove all backslash characters', async () => {
-      expect(sanitisePermitNumber('ABC\\123\\456')).toEqual('ABC123456')
-    })
-
-    it('should remove all dash characters', async () => {
-      expect(sanitisePermitNumber('ABC-123-456')).toEqual('ABC123456')
-    })
-
-    it('should remove all dot characters', async () => {
-      expect(sanitisePermitNumber('ABC.123.456')).toEqual('ABC123456')
+    describe('Discharges to water and groundwater (Water Quality Discharge Consents)', () => {
+      it('should...', () => {
+        // TODO Story 19604 Add other tests once the matching criteria have been defined
+      })
     })
   })
 
   describe('validateDate method', () => {
-    it('should validate and format dates correctly', async () => {
+    it('should validate and format dates correctly', () => {
       expect(validateDate('')).toEqual({ formattedDate: '', isValid: true, originalDate: '', timestamp: null })
 
       expect(validateDate('jan 2020')).toEqual({


### PR DESCRIPTION
Story 19604

This change ensures that exact match searches are carried out when a user queries for documents via the Enter Permit Number page.

The selected register is mapped to the expected format contained in the metadata. The entered permit number is sanitised and formatted using some register-specific logic.

Note that the logic for register 'Water Quality Discharge Consents' has yet to be defined so this matching logic will need to be added at a later date.