### PR TITLE
Add user email to contact result page

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -21,7 +21,7 @@ Constants.Views = {
   },
   CONTACT_COMPLETE: {
     route: 'contact-complete',
-    pageHeading: 'CONTACT COMPLETE'
+    pageHeading: 'Contact complete'
   },
   DOWNLOAD: {
     route: 'download',

--- a/src/modules/enter-permit-number.njk
+++ b/src/modules/enter-permit-number.njk
@@ -23,17 +23,13 @@
 {% endset -%}
 
 {% block formContent %}
+  <h1 id="page-heading" class="govuk-heading-xl">{{ pageHeading }}</h1>
+
+  <p id="register-hint" class="govuk-body govuk-!-margin-bottom-6">{{ registerHint }}</p>
+
   {{ govukRadios({
     idPrefix: "knowPermitNumber",
     name: "knowPermitNumber",
-    fieldset: {
-      legend: {
-        text: pageHeading,
-        isPageHeading: true,
-        classes: "govuk-fieldset__legend--l"
-      }
-    },
-    errorMessage: fieldErrors['knowPermitNumber'],
     items: [
       {
         value: "yes",
@@ -51,7 +47,8 @@
           html: eprReferral
         }
       }
-    ]
+    ],
+    errorMessage: fieldErrors['knowPermitNumber']
   }) }}
 
   {{ govukButton({

--- a/src/modules/enter-permit-number.route.js
+++ b/src/modules/enter-permit-number.route.js
@@ -6,7 +6,7 @@ const { logger } = require('defra-logging-facade')
 const { handleValidationErrors, raiseCustomValidationError } = require('../utils/validation')
 const { sanitisePermitNumber } = require('../utils/general')
 
-const { Views } = require('../constants')
+const { Registers, Views } = require('../constants')
 
 const AppInsightsService = require('../services/app-insights.service')
 const MiddlewareService = require('../services/middleware.service')
@@ -120,6 +120,28 @@ const _getContext = request => {
     pageHeading: Views.ENTER_PERMIT_NUMBER.pageHeading,
     knowPermitNumber: request.payload ? request.payload.knowPermitNumber : null,
     permitNumber: request.payload ? request.payload.permitNumber : null,
-    register: request.query ? request.query.register : null
+    register: request.query ? request.query.register : null,
+    registerHint: _getRegiserHint(request)
+  }
+}
+
+const _getRegiserHint = request => {
+  const wasteRegisterHint =
+    "Permit numbers will start with 'EAWML' or 'EPR' followed by a combination of numbers (e.g. EAWML 123456) or letters and numbers (e.g. EPR-AB1234CD)"
+
+  const installationsAndRadioactiveRegisterHint =
+    "Permit numbers will start with 'EPR' followed by a combination of letters and numbers (e.g. EPR-AB1234CD)"
+
+  const waterRegisterHint =
+    'Permit numbers are usually a combination of both letters and numbers. They vary based on region, you can view a guide to the different formats used HERE'
+
+  switch (request.query.register) {
+    case Registers.WASTE_OPERATIONS:
+      return wasteRegisterHint
+    case Registers.INSTALLATIONS:
+    case Registers.RADIOACTIVE_SUBSTANCES:
+      return installationsAndRadioactiveRegisterHint
+    case Registers.DISCHARGES_TO_WATER_AND_GROUNDWATER:
+      return waterRegisterHint
   }
 }

--- a/test/routes/enter-permit-number.route.test.js
+++ b/test/routes/enter-permit-number.route.test.js
@@ -18,6 +18,8 @@ describe('Enter Permit Number route', () => {
   const nextUrlUnknownPermitNumber = '/epr-redirect'
 
   const elementIDs = {
+    pageHeading: 'page-heading',
+    registerHint: 'register-hint',
     yesOption: 'knowPermitNumber',
     noOption: 'knowPermitNumber-2',
     permitNumberField: 'permitNumber',
@@ -63,7 +65,7 @@ describe('Enter Permit Number route', () => {
     })
 
     it('should display the correct question', () => {
-      const element = document.querySelector('.govuk-fieldset__legend')
+      const element = document.querySelector(`#${elementIDs.pageHeading}`)
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(
         'Do you know the permit number of the record you are looking for?'
@@ -262,6 +264,25 @@ describe('Enter Permit Number route', () => {
           })
         )
       })
+    })
+  })
+
+  describe('GET - Permit number hint', () => {
+    const getOptions = {
+      method: 'GET',
+      url
+    }
+
+    beforeEach(async () => {
+      document = await TestHelper.submitGetRequest(server, getOptions)
+    })
+
+    it('should display the correct hint for Installations', () => {
+      const element = document.querySelector(`#${elementIDs.registerHint}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(
+        "Permit numbers will start with 'EPR' followed by a combination of letters and numbers (e.g. EPR-AB1234CD)"
+      )
     })
   })
 })


### PR DESCRIPTION
Story 20130

Added the user's email to the Contact Result page so that the user knows which email they entered and where they can expect their response to go to.