### PR TITLE
Added email to contact result page

### DIFF
--- a/src/modules/contact-complete.njk
+++ b/src/modules/contact-complete.njk
@@ -12,7 +12,7 @@
 
   <h2 id="what-happens-next" class="govuk-heading-m">What happens next</h2>
 
-  <p id="email-confirmation-text" class="govuk-body">You should receive a confirmation email in the next 24 hours to confirm your request has been successfully submitted. If you don't get this, please resubmit your request or contact us.</p>
+  <p id="email-confirmation-text" class="govuk-body">We will send a confirmation email to <span class="govuk-!-font-weight-bold">{{ email }}</span> in the next 24 hours to confirm your request has been successfully submitted. </p>
   
   <p id="timescale-text" class="govuk-body">You should receive a response to your request within the next {{ timescale }} working days.</p>
 

--- a/src/modules/contact-complete.route.js
+++ b/src/modules/contact-complete.route.js
@@ -7,8 +7,11 @@ module.exports = [
   {
     method: 'GET',
     handler: async (request, h) => {
+      const email = decodeURIComponent(request.query.email)
+
       return h.view(Views.CONTACT_COMPLETE.route, {
         pageHeading: Views.CONTACT_COMPLETE.pageHeading,
+        email,
         timescale: config.informationRequestTimescale
       })
     }

--- a/src/modules/contact.route.js
+++ b/src/modules/contact.route.js
@@ -49,7 +49,7 @@ module.exports = [
         }
       }
 
-      return h.continue
+      return h.redirect(`/${Views.CONTACT_COMPLETE.route}?email=${encodeURIComponent(context.email)}`)
     },
 
     options: {

--- a/src/modules/map.yml
+++ b/src/modules/map.yml
@@ -32,7 +32,7 @@ contact:
   route: contact.route
 
 contact-complete:
-  path: /contact/complete
+  path: /contact-complete
   route: contact-complete.route
   tags:
     - hide-back-link

--- a/test/routes/contact-complete.route.test.js
+++ b/test/routes/contact-complete.route.test.js
@@ -5,7 +5,8 @@ const server = require('../../src/server')
 const TestHelper = require('../utilities/test-helper')
 
 describe('Contact complete route', () => {
-  const url = '/contact/complete'
+  const email = 'someone@somewhere.com'
+  const url = `/contact-complete?email=${email}`
 
   const elementIDs = {
     requestSentPanel: 'request-sent-panel',
@@ -69,7 +70,7 @@ describe('Contact complete route', () => {
       const element = document.querySelector(`#${elementIDs.emailConfirmationText}`)
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(
-        "You should receive a confirmation email in the next 24 hours to confirm your request has been successfully submitted. If you don't get this, please resubmit your request or contact us."
+        `We will send a confirmation email to ${email} in the next 24 hours to confirm your request has been successfully submitted.`
       )
     })
 

--- a/test/routes/contact.route.test.js
+++ b/test/routes/contact.route.test.js
@@ -13,7 +13,7 @@ const TestHelper = require('../utilities/test-helper')
 describe('Contact route', () => {
   const url =
     '/contact?permitNumber=EAWML 65519&site=Site%20On%20Trevor%20Street&register=Installations&address=3%20Trevor%20Street%20Hull%20Humberside&postcode=HU2%200HR'
-  const nextUrl = '/contact/complete'
+  const nextUrl = '/contact-complete'
   const FURTHER_INFO_CHARACTER_LIMIT = 5000
 
   const elementIDs = {
@@ -220,7 +220,7 @@ describe('Contact route', () => {
         expect(NotificationService.prototype.sendCustomerEmail).toBeCalledTimes(1)
         expect(NotificationService.prototype.sendNcccEmail).toBeCalledTimes(1)
 
-        expect(response.headers.location).toEqual(nextUrl)
+        expect(response.headers.location).toEqual(`${nextUrl}?email=someone%40somewhere.com`)
       })
     })
 


### PR DESCRIPTION
Story 20130

Added the user's email to the Contact Result page so that the user knows which email they entered and where they can expect their response to go to.