### PR TITLE
Permit number help text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "public-register-of-documents-frontend",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "description": "DEFRA Public Register of Documents frontend",
   "main": "server.js",
   "homepage": "https://github.com/DEFRA/public-register-of-documents-frontend#readme",

--- a/src/constants.js
+++ b/src/constants.js
@@ -21,7 +21,7 @@ Constants.Views = {
   },
   CONTACT_COMPLETE: {
     route: 'contact-complete',
-    pageHeading: 'CONTACT COMPLETE'
+    pageHeading: 'Contact complete'
   },
   DOWNLOAD: {
     route: 'download',

--- a/src/modules/enter-permit-number.njk
+++ b/src/modules/enter-permit-number.njk
@@ -23,17 +23,13 @@
 {% endset -%}
 
 {% block formContent %}
+  <h1 id="page-heading" class="govuk-heading-xl">{{ pageHeading }}</h1>
+
+  <p id="register-hint" class="govuk-body govuk-!-margin-bottom-6">{{ registerHint }}</p>
+
   {{ govukRadios({
     idPrefix: "knowPermitNumber",
     name: "knowPermitNumber",
-    fieldset: {
-      legend: {
-        text: pageHeading,
-        isPageHeading: true,
-        classes: "govuk-fieldset__legend--l"
-      }
-    },
-    errorMessage: fieldErrors['knowPermitNumber'],
     items: [
       {
         value: "yes",
@@ -51,7 +47,8 @@
           html: eprReferral
         }
       }
-    ]
+    ],
+    errorMessage: fieldErrors['knowPermitNumber']
   }) }}
 
   {{ govukButton({

--- a/src/modules/enter-permit-number.route.js
+++ b/src/modules/enter-permit-number.route.js
@@ -6,7 +6,7 @@ const { logger } = require('defra-logging-facade')
 const { handleValidationErrors, raiseCustomValidationError } = require('../utils/validation')
 const { sanitisePermitNumber } = require('../utils/general')
 
-const { Views } = require('../constants')
+const { Registers, Views } = require('../constants')
 
 const AppInsightsService = require('../services/app-insights.service')
 const MiddlewareService = require('../services/middleware.service')
@@ -120,6 +120,28 @@ const _getContext = request => {
     pageHeading: Views.ENTER_PERMIT_NUMBER.pageHeading,
     knowPermitNumber: request.payload ? request.payload.knowPermitNumber : null,
     permitNumber: request.payload ? request.payload.permitNumber : null,
-    register: request.query ? request.query.register : null
+    register: request.query ? request.query.register : null,
+    registerHint: _getRegiserHint(request)
+  }
+}
+
+const _getRegiserHint = request => {
+  const wasteRegisterHint =
+    "Permit numbers will start with 'EAWML' or 'EPR' followed by a combination of numbers (e.g. EAWML 123456) or letters and numbers (e.g. EPR-AB1234CD)"
+
+  const installationsAndRadioactiveRegisterHint =
+    "Permit numbers will start with 'EPR' followed by a combination of letters and numbers (e.g. EPR-AB1234CD)"
+
+  const waterRegisterHint =
+    'Permit numbers are usually a combination of both letters and numbers. They vary based on region, you can view a guide to the different formats used HERE'
+
+  switch (request.query.register) {
+    case Registers.WASTE_OPERATIONS:
+      return wasteRegisterHint
+    case Registers.INSTALLATIONS:
+    case Registers.RADIOACTIVE_SUBSTANCES:
+      return installationsAndRadioactiveRegisterHint
+    case Registers.DISCHARGES_TO_WATER_AND_GROUNDWATER:
+      return waterRegisterHint
   }
 }

--- a/src/modules/enter-permit-number.route.js
+++ b/src/modules/enter-permit-number.route.js
@@ -132,8 +132,7 @@ const _getRegiserHint = request => {
   const installationsAndRadioactiveRegisterHint =
     "Permit numbers will start with 'EPR' followed by a combination of letters and numbers (e.g. EPR-AB1234CD)"
 
-  const waterRegisterHint =
-    'Permit numbers are usually a combination of both letters and numbers. They vary based on region, you can view a guide to the different formats used HERE'
+  const waterRegisterHint = 'Permit numbers are usually a combination of both letters and numbers'
 
   switch (request.query.register) {
     case Registers.WASTE_OPERATIONS:

--- a/test/routes/enter-permit-number.route.test.js
+++ b/test/routes/enter-permit-number.route.test.js
@@ -13,7 +13,7 @@ const mockData = require('../data/permit-data')
 
 describe('Enter Permit Number route', () => {
   const register = 'Installations'
-  const url = `/enter-permit-number?register=${register}`
+  const url = '/enter-permit-number'
   const nextUrlKnownPermitNumber = '/view-permit-documents'
   const nextUrlUnknownPermitNumber = '/epr-redirect'
 
@@ -49,7 +49,7 @@ describe('Enter Permit Number route', () => {
   describe('GET', () => {
     const getOptions = {
       method: 'GET',
-      url
+      url: `${url}?register=${register}`
     }
 
     beforeEach(async () => {
@@ -107,7 +107,7 @@ describe('Enter Permit Number route', () => {
     beforeEach(() => {
       postOptions = {
         method: 'POST',
-        url,
+        url: `${url}?register=${register}`,
         payload: {}
       }
     })
@@ -268,21 +268,48 @@ describe('Enter Permit Number route', () => {
   })
 
   describe('GET - Permit number hint', () => {
+    const expectedHint1 =
+      "Permit numbers will start with 'EAWML' or 'EPR' followed by a combination of numbers (e.g. EAWML 123456) or letters and numbers (e.g. EPR-AB1234CD)"
+
+    const expectedHint2 =
+      "Permit numbers will start with 'EPR' followed by a combination of letters and numbers (e.g. EPR-AB1234CD)"
+
+    const expectedHint3 = 'Permit numbers are usually a combination of both letters and numbers'
+
     const getOptions = {
-      method: 'GET',
-      url
+      method: 'GET'
     }
 
-    beforeEach(async () => {
+    it('should display the correct hint for "Waste Operations" and "End of Life vehicles"', async () => {
+      getOptions.url = `${url}?register=Waste Operations`
       document = await TestHelper.submitGetRequest(server, getOptions)
-    })
-
-    it('should display the correct hint for Installations', () => {
       const element = document.querySelector(`#${elementIDs.registerHint}`)
       expect(element).toBeTruthy()
-      expect(TestHelper.getTextContent(element)).toEqual(
-        "Permit numbers will start with 'EPR' followed by a combination of letters and numbers (e.g. EPR-AB1234CD)"
-      )
+      expect(TestHelper.getTextContent(element)).toEqual(expectedHint1)
+    })
+
+    it('should display the correct hint for "Installations"', async () => {
+      getOptions.url = `${url}?register=Installations`
+      document = await TestHelper.submitGetRequest(server, getOptions)
+      const element = document.querySelector(`#${elementIDs.registerHint}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(expectedHint2)
+    })
+
+    it('should display the correct hint for "Radioactive Substances"', async () => {
+      getOptions.url = `${url}?register=Radioactive Substances`
+      document = await TestHelper.submitGetRequest(server, getOptions)
+      const element = document.querySelector(`#${elementIDs.registerHint}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(expectedHint2)
+    })
+
+    it('should display the correct hint for "Discharges to water and groundwater"', async () => {
+      getOptions.url = `${url}?register=Water Quality Discharge Consents`
+      document = await TestHelper.submitGetRequest(server, getOptions)
+      const element = document.querySelector(`#${elementIDs.registerHint}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(expectedHint3)
     })
   })
 })

--- a/test/routes/enter-permit-number.route.test.js
+++ b/test/routes/enter-permit-number.route.test.js
@@ -18,6 +18,8 @@ describe('Enter Permit Number route', () => {
   const nextUrlUnknownPermitNumber = '/epr-redirect'
 
   const elementIDs = {
+    pageHeading: 'page-heading',
+    registerHint: 'register-hint',
     yesOption: 'knowPermitNumber',
     noOption: 'knowPermitNumber-2',
     permitNumberField: 'permitNumber',
@@ -63,7 +65,7 @@ describe('Enter Permit Number route', () => {
     })
 
     it('should display the correct question', () => {
-      const element = document.querySelector('.govuk-fieldset__legend')
+      const element = document.querySelector(`#${elementIDs.pageHeading}`)
       expect(element).toBeTruthy()
       expect(TestHelper.getTextContent(element)).toEqual(
         'Do you know the permit number of the record you are looking for?'
@@ -262,6 +264,25 @@ describe('Enter Permit Number route', () => {
           })
         )
       })
+    })
+  })
+
+  describe('GET - Permit number hint', () => {
+    const getOptions = {
+      method: 'GET',
+      url
+    }
+
+    beforeEach(async () => {
+      document = await TestHelper.submitGetRequest(server, getOptions)
+    })
+
+    it('should display the correct hint for Installations', () => {
+      const element = document.querySelector(`#${elementIDs.registerHint}`)
+      expect(element).toBeTruthy()
+      expect(TestHelper.getTextContent(element)).toEqual(
+        "Permit numbers will start with 'EPR' followed by a combination of letters and numbers (e.g. EPR-AB1234CD)"
+      )
     })
   })
 })


### PR DESCRIPTION
Story 19932

Add register-specific help text on the Enter Permit Number screen to guide users on the required format for permit numbers.